### PR TITLE
Add Dependency rails v4.1.0

### DIFF
--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'sqlite3-ruby'
   gem.add_development_dependency 'hpricot'
   gem.add_development_dependency 'git'
+
+  gem.add_dependency 'rails', '~> 4.1.0'
 end


### PR DESCRIPTION
Rails を 4.1.0 以前を利用してても、bundle update した際に jpmobile が 4.1.0 へ更新されてしまっているので、それが防げるのではないかと追加してみました。
